### PR TITLE
Add audit workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,28 @@
+name: Run Audit
+
+on:
+  push:
+    paths:
+      - 'input_sites/**'
+  pull_request:
+    paths:
+      - 'input_sites/**'
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run audit script
+        run: node scripts/audit-sites.js
+      - name: Upload results
+        uses: actions/upload-artifact@v3
+        with:
+          name: audit-results
+          path: output

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ package-lock.json
 /blob-report/
 /playwright/.cache/
 /test
+output/
 .env

--- a/input_sites/sites.txt
+++ b/input_sites/sites.txt
@@ -1,0 +1,2 @@
+biancazapatka.com
+cafedelites.com

--- a/scripts/audit-sites.js
+++ b/scripts/audit-sites.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+const got = require('got');
+
+const inputFile = path.join(__dirname, '..', 'input_sites', 'sites.txt');
+const outputDir = path.join(__dirname, '..', 'output');
+
+async function run() {
+  const sites = fs.readFileSync(inputFile, 'utf-8')
+    .split(/\r?\n/)
+    .filter(Boolean);
+  fs.mkdirSync(outputDir, { recursive: true });
+  for (const site of sites) {
+    console.log(`Auditing ${site}`);
+    try {
+      const response = await got(`https://${site}`);
+      const fileName = site.replace(/[^a-zA-Z0-9.-]/g, '_') + '.html';
+      fs.writeFileSync(path.join(outputDir, fileName), response.body);
+    } catch (err) {
+      console.error(`Failed to audit ${site}: ${err.message}`);
+    }
+  }
+}
+
+run();


### PR DESCRIPTION
## Summary
- create input_sites/sites.txt with initial sites
- add audit script that fetches each site and writes to output
- ignore output directory
- add GitHub Actions workflow to run the audit when sites list changes

## Testing
- `node scripts/audit-sites.js` *(fails: getaddrinfo ENOTFOUND cafedelites.com)*

------
https://chatgpt.com/codex/tasks/task_b_68823d451cf8832ba21aa4a4ce030073