### PR TITLE
Allow URL auditing and update workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run audit script
         run: node scripts/audit-sites.js
       - name: Upload results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: audit-results
           path: output

--- a/input_sites/sites.txt
+++ b/input_sites/sites.txt
@@ -1,2 +1,2 @@
-biancazapatka.com
-cafedelites.com
+https://biancazapatka.com/de/
+https://cafedelites.com/butter-chicken/

--- a/scripts/audit-sites.js
+++ b/scripts/audit-sites.js
@@ -13,8 +13,9 @@ async function run() {
   for (const site of sites) {
     console.log(`Auditing ${site}`);
     try {
-      const response = await got(`https://${site}`);
-      const fileName = site.replace(/[^a-zA-Z0-9.-]/g, '_') + '.html';
+      const url = site.startsWith('http') ? site : `https://${site}`;
+      const response = await got(url);
+      const fileName = url.replace(/[^a-zA-Z0-9.-]/g, '_') + '.html';
       fs.writeFileSync(path.join(outputDir, fileName), response.body);
     } catch (err) {
       console.error(`Failed to audit ${site}: ${err.message}`);


### PR DESCRIPTION
## Summary
- handle full URLs in `audit-sites.js`
- audit two new URLs
- use `actions/upload-artifact@v4` in audit workflow

## Testing
- `npm install`
- `node scripts/audit-sites.js` *(fails: connect ENETUNREACH)*
- `npm test` *(fails: Chrome browser missing)*

------
https://chatgpt.com/codex/tasks/task_b_68823fe96da4832b847c165d806da54f