### PR TITLE
Fix unit test imports

### DIFF
--- a/src/app/modules/entries/entries.component.spec.ts
+++ b/src/app/modules/entries/entries.component.spec.ts
@@ -8,7 +8,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { EntriesComponent } from './entries.component';
 import { SharedModule } from 'src/app/shared/shared.module';
 import { MaterialAllModule } from 'src/app/material.module';
-import { EntriesModule } from './entries.module';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('EntriesComponent', () => {
   let component: EntriesComponent;
@@ -16,7 +16,7 @@ describe('EntriesComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    imports: [MaterialAllModule, SharedModule, EntriesModule, EntriesComponent]
+    imports: [MaterialAllModule, RouterTestingModule, SharedModule, EntriesComponent]
 })
     .compileComponents();
 

--- a/src/app/modules/others/settings/settings.component.spec.ts
+++ b/src/app/modules/others/settings/settings.component.spec.ts
@@ -8,7 +8,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SettingsComponent } from './settings.component';
 import { MaterialAllModule } from 'src/app/material.module';
 import { SharedModule } from 'src/app/shared/shared.module';
-import { OthersModule } from '../others.module';
 
 describe('SettingsComponent', () => {
   let component: SettingsComponent;
@@ -16,7 +15,7 @@ describe('SettingsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    imports: [MaterialAllModule, SharedModule, OthersModule, SettingsComponent]
+    imports: [MaterialAllModule, SharedModule, SettingsComponent]
 })
     .compileComponents();
 

--- a/src/app/modules/report/report.component.spec.ts
+++ b/src/app/modules/report/report.component.spec.ts
@@ -11,7 +11,6 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { SharedModule } from 'src/app/shared/shared.module';
 import { ReportRendererComponent } from './report-renderer/report-renderer.component';
 import 'tinymce';
-import { ReportModule } from './report.module';
 
 describe('ReportComponent', () => {
   let component: ReportComponent;
@@ -19,7 +18,7 @@ describe('ReportComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    imports: [MaterialAllModule, RouterTestingModule, SharedModule, ReportModule, ReportComponent, ReportRendererComponent]
+    imports: [MaterialAllModule, RouterTestingModule, SharedModule, ReportComponent, ReportRendererComponent]
 })
     .compileComponents();
 

--- a/src/app/modules/report/toolbar/toolbar.component.spec.ts
+++ b/src/app/modules/report/toolbar/toolbar.component.spec.ts
@@ -6,7 +6,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ToolbarComponent } from './toolbar.component';
-import { ReportModule } from '../report.module';
 
 describe('ToolbarComponent', () => {
   let component: ToolbarComponent;
@@ -14,7 +13,7 @@ describe('ToolbarComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-    imports: [ReportModule, ToolbarComponent]
+    imports: [ToolbarComponent]
 });
     fixture = TestBed.createComponent(ToolbarComponent);
     component = fixture.componentInstance;


### PR DESCRIPTION
## Summary
- drop references to removed feature modules in unit tests

## Testing
- `npm run ng:test -- --watch=false --browsers=ChromeHeadless` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_b_688263f39d30832b9cae9815496c2f2f