### PR TITLE
Add CI workflow for Playwright tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,26 @@
+name: Run E2E Tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright Browsers
+        uses: microsoft/playwright-github-action@v1
+      - name: Build app
+        run: npm run build
+      - name: Run e2e tests
+        run: npm run e2e
+        env:
+          CI: true


### PR DESCRIPTION
## Summary
- run Playwright end-to-end tests in CI

## Testing
- `npm run ng:test -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless requires --no-sandbox when running as root)*
- `npm run e2e` *(fails: tests cannot run in container)*

------
https://chatgpt.com/codex/tasks/task_b_68826acc55b8832b90b0be94341389de