### PR TITLE
Fix failing tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -37,7 +37,13 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ['ChromeHeadlessNoSandbox'],
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox']
+      }
+    },
     singleRun: false,
     restartOnFileChange: true
   });

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -12,9 +12,8 @@ import { MaterialAllModule } from './material.module';
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    declarations: [AppComponent],
-    imports: [MaterialAllModule, RouterTestingModule, SharedModule]
-}).compileComponents();
+      imports: [MaterialAllModule, RouterTestingModule, SharedModule, AppComponent]
+    }).compileComponents();
   });
 
   it('should create the app', () => {

--- a/src/app/modules/analysis/tags/tags.component.spec.ts
+++ b/src/app/modules/analysis/tags/tags.component.spec.ts
@@ -7,6 +7,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TagsComponent } from './tags.component';
 import { MaterialAllModule } from 'src/app/material.module';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('TagsComponent', () => {
   let component: TagsComponent;
@@ -14,8 +15,8 @@ describe('TagsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    imports: [MaterialAllModule, TagsComponent]
-})
+      imports: [MaterialAllModule, RouterTestingModule, TagsComponent]
+    })
     .compileComponents();
 
     fixture = TestBed.createComponent(TagsComponent);

--- a/src/app/services/analysis.service.spec.ts
+++ b/src/app/services/analysis.service.spec.ts
@@ -17,6 +17,7 @@ describe('AnalysisService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({});
     service = TestBed.inject(AnalysisService);
+    spyOn(window, 'fetch').and.returnValue(Promise.resolve(new Response(new Blob(['data']))));
   });
 
   it('should be created', () => {


### PR DESCRIPTION
## Summary
- fix testbed setup for standalone AppComponent
- include RouterTestingModule in TagsComponent tests
- stub `fetch` in AnalysisService tests to avoid network
- update Karma config with ChromeHeadlessNoSandbox launcher

## Testing
- `CHROME_BIN=$(which google-chrome) npm run ng:test -- --watch=false --browsers=ChromeHeadlessNoSandbox`

------
https://chatgpt.com/codex/tasks/task_b_6882946e50b4832bb9de887f353eb0ea