### PR TITLE
Fix Playwright setup on Ubuntu 24.04

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright Browsers
-        uses: microsoft/playwright-github-action@v1
+        run: npx playwright install --with-deps
       - name: Build app
         run: npm run build
       - name: Run e2e tests


### PR DESCRIPTION
## Summary
- update the e2e workflow to use `npx playwright install --with-deps`

## Testing
- `npx playwright install --with-deps`
- `npm run e2e` *(fails: 9 failed, 6 did not run)*

------
https://chatgpt.com/codex/tasks/task_b_6882949c7ba0832ba66cc22797d46d14