### PR TITLE
Fix fetch spy to return fresh Response in AnalysisService spec

### DIFF
--- a/src/app/services/analysis.service.spec.ts
+++ b/src/app/services/analysis.service.spec.ts
@@ -17,7 +17,9 @@ describe('AnalysisService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({});
     service = TestBed.inject(AnalysisService);
-    spyOn(window, 'fetch').and.returnValue(Promise.resolve(new Response(new Blob(['data']))));
+    spyOn(window, 'fetch').and.callFake(() =>
+      Promise.resolve(new Response(new Blob(['data'])))
+    );
   });
 
   it('should be created', () => {


### PR DESCRIPTION
## Summary
- ensure the mocked `fetch` returns a new `Response` each call to avoid `body stream already read` errors

## Testing
- `npm run ng:test -- --watch=false --browsers=ChromeHeadlessNoSandbox`

------
https://chatgpt.com/codex/tasks/task_b_6882b21c7e0c832ba4732dcaace52ef6