### PR TITLE
Set CET timezone for Electron browser

### DIFF
--- a/app/handlers/sessions/browser-session.ts
+++ b/app/handlers/sessions/browser-session.ts
@@ -123,6 +123,15 @@ export class BrowserSession {
 
     async create() {
         await this.collector.createCollector(this._view);
+        try {
+            this.contents.debugger.attach('1.3');
+            this.contents.debugger.sendCommand('Emulation.setTimezoneOverride', {
+                timezoneId: 'Europe/Paris'
+            });
+            this.contents.debugger.detach();
+        } catch (e) {
+            console.error('Failed to set timezone:', e);
+        }
     }
 
     delete() {


### PR DESCRIPTION
## Summary
- set Chrome DevTools timezone override to `Europe/Paris` when creating a BrowserSession

## Testing
- `npm run ng:test -- --watch=false`

------
https://chatgpt.com/codex/tasks/task_b_6887811e8bd8832b8731ee66dad55330